### PR TITLE
[WIP] Add possibility assign selected file with model

### DIFF
--- a/js/jquery.fileupload-angular.js
+++ b/js/jquery.fileupload-angular.js
@@ -221,6 +221,14 @@
                 };
                 $scope.disabled = !$window.jQuery.support.fileInput;
                 $scope.queue = $scope.queue || [];
+
+                var model = $attrs['file-model'];
+                var multiple = $attrs['multiple'];
+
+                if (model) {
+                    $scope[model] = multiple ? $scope.queue : $scope.queue[0];
+                }
+
                 $scope.clear = function (files) {
                     var queue = this.queue,
                         i = queue.length,


### PR DESCRIPTION
This PR more than feature request instead of concrete implementation.

Currently angular module add `queue` variable to scope. It does not useful for single file uploads, better add possibility choose scope variable name and assign first file from queue when file input doesn't supports multiple files selection. Also it would be nice add possibility add more than one file input to the form and store them into separate models. See code example below

``` html
<span class="file-btn button white-bg is-bordered ie-radius" ng-if="productsFile"><%= productsFile.name %></span>
<span class="file-btn button white-bg is-bordered ie-radius" ng-if="!productsFile">Select file...</span>

<input type="file" name="products_importform[attachment]" file-model="productsFile" ng-disabled="ymlUrl" />

<input type="url" name="products_importform[ymlUrl]" model="ymlUrl" ng-disabled="productsFile" />
```

Current code implementation is not ready and just concept.
